### PR TITLE
Add full Dockerfile and update doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,3 @@ monitoring/grafana
 
 # Plugins (to avoid any jar file to hit the repo unintentionally)
 plugins/
-
-# Installation instructions in 01_installation.md do a git clone of an external repository
-# inside own-jdbc-connector/. This entry ensures that such external repository is not
-# commited in ours unintentionally
-own-jdbc-connector/kafka-connect-jdbc

--- a/doc/04_docker.md
+++ b/doc/04_docker.md
@@ -47,6 +47,9 @@ PostGIS and Monitoring are commented out by default.
 ./docker-up.sh
 ```
 
+> You can pass arguments like `-d` to run in detached mode.
+
+
 ### `docker-down.sh`
 
 Stops the same services and removes volumes & orphan containers:
@@ -55,11 +58,17 @@ Stops the same services and removes volumes & orphan containers:
 ./docker-down.sh
 ```
 
-> You can pass arguments like `-d` to run in detached mode (`--build` argument it is present by default).
-
 ---
 
 ## 🧱 Compose Files Summary
+
+The Docker Compose setup relies on two custom images:
+
+- **Kafka Connect** is built using `kafka-connect-custom/Dockerfile`, which includes all required connectors and plugins during the image build process.
+- **Faust** is built using `kafka-ngsi-stream/Dockerfile`, which includes the stream processing app and all dependencies.
+
+Both images are automatically built via `docker-up.sh`, so you don't need to build them manually unless debugging or developing.
+
 
 ### `docker-compose.kafka.yml`
 
@@ -166,7 +175,9 @@ docker network create kafka-postgis-net
 
 ## ⚙️ Plugins
 
-Kafka Connect copy plugins from:
+Kafka Connect plugins are automatically bundled during image build (inside [`kafka-connect-custom/Dockerfile`](/kafka-connect-custom/Dockerfile)).
+
+The plugin directory (`kafka-connect-custom/plugins/`) contains:
 
 - `kafka-connect-custom/plugins/`: contains:
   - `header-router` (custom SMT)
@@ -174,13 +185,11 @@ Kafka Connect copy plugins from:
   - `mongodb` connector
   - `mqtt-kafka-connect` temporal bridge between CB and Kafka
 
-Plugins are referenced by `CONNECT_PLUGIN_PATH`.
-
 ---
 
 ## 🧪 Notes for Testing
 
-The test suite can also dynamically start these containers via **Testcontainers** when running end-to-end tests. See `doc/08_testing.md`.
+The test suite can also dynamically start these containers via **Testcontainers** when running end-to-end tests. See [`08_testing.md`](doc/08_testing.md).
 
 ---
 

--- a/doc/06_kafka_connect.md
+++ b/doc/06_kafka_connect.md
@@ -10,7 +10,7 @@ This document explains how Kafka Connect is configured to persist NGSI notificat
 This project uses Docker Compose to orchestrate the multi-service environment, including Kafka Connect and other components.
 
 **Important:**  
-We override the default `docker-compose` CLI used by some tools and libraries to instead use the latest Docker Compose V2 syntax (`docker compose`). This ensures compatibility with the newest Docker CLI features and avoids issues related to the deprecated `docker-compose` command.
+In tests, we override the default `docker-compose` CLI used by some tools and libraries to instead use the latest Docker Compose V2 syntax (`docker compose`). This ensures compatibility with the newest Docker CLI features and avoids issues related to the deprecated `docker-compose` command.
 
 The custom Python fixture leverages this by substituting commands so that all compose operations run through `docker compose` (V2), not `docker-compose` (V1).
 
@@ -20,7 +20,10 @@ The custom Python fixture leverages this by substituting commands so that all co
 
 ## 🧩 Kafka Connect Plugins
 
-Located under the `kafka-connect-custom/plugins/` directory:
+Kafka Connect plugins are automatically built into the Docker image.
+
+You can inspect them at runtime under the `kafka-connect-custom/plugins/` directory.  
+This directory is **populated automatically** during the Docker build using the logic defined in the [Dockerfile](/kafka-connect-custom/Dockerfile).
 
 ### 1. JDBC Plugin for PostGIS
 
@@ -122,6 +125,8 @@ curl -X POST http://localhost:8083/connectors \
   -H "Content-Type: application/json" \
   --data @pg-sink-historic.json
 ```
+
+> ℹ️ Ensure the `tests` database exists before registering the connectors.  
 
 Repeat the same process for the other configuration files:
 

--- a/doc/08_testing.md
+++ b/doc/08_testing.md
@@ -116,10 +116,7 @@ USE_EXTERNAL_POSTGIS=true pytest -s test_pipeline.py -k "000A or 000B"
 You can filter scenarios using `-k` and their directory names or tags.
 
 
-> ⚠️ Note about Docker images  
-> The `docker-compose.*.yml` files specify the `image:` option for Faust and custom Kafka Connect.  
-> If the image is not present locally, Docker Compose will try to pull it from the registry (Docker Hub by default) and will show a warning if the image is not found.  
-> For now, this warning is expected and does not affect test execution, as images are built dynamically or local images are used depending on the environment.
+> ⚠️ Remember that a warning will be displayed if the images have not been built.
 
 
 ---

--- a/kafka-connect-custom/Dockerfile
+++ b/kafka-connect-custom/Dockerfile
@@ -24,22 +24,93 @@
 
 FROM confluentinc/cp-kafka-connect:7.9.0
 
-# Create plugin directory with correct permissions
 USER root
-RUN mkdir -p /usr/local/share/kafka-connect/plugins && \
-    chown -R appuser:appuser /usr/local/share/kafka-connect/plugins
 
-# Copy all plugins to an alternative location with proper permissions
-COPY --chown=appuser:appuser plugins/ /usr/local/share/kafka-connect/plugins/
+# -----------------------------
+# Install build dependencies
+# -----------------------------
+RUN microdnf install -y \
+    java-17-openjdk-devel \
+    git \
+    wget \
+    tar \
+    gzip \
+    && microdnf clean all
 
-# Copy monitoring configuration
-COPY monitoring/jmx_prometheus_javaagent.jar /usr/share/jmx_exporter/
+# Install Maven 3.9.7
+RUN wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.tar.gz -P /tmp && \
+    tar xf /tmp/apache-maven-3.9.7-bin.tar.gz -C /opt && \
+    ln -s /opt/apache-maven-3.9.7 /opt/maven && \
+    rm /tmp/apache-maven-3.9.7-bin.tar.gz
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${PATH}"
+
+# -----------------------------
+# Create plugin directories
+# -----------------------------
+RUN mkdir -p /usr/local/share/kafka-connect/plugins \
+    && chown -R appuser:appuser /usr/local/share/kafka-connect/plugins
+
+# -----------------------------
+# Build HeaderRouter
+# -----------------------------
+COPY src/header-router /tmp/header-router
+RUN cd /tmp/header-router && \
+    mvn clean package && \
+    mkdir -p /usr/local/share/kafka-connect/plugins/header-router && \
+    cp target/header-router-1.0.0-jar-with-dependencies.jar /usr/local/share/kafka-connect/plugins/header-router/header-router-1.0.0.jar
+
+# -----------------------------
+# Build MQTT Connector
+# -----------------------------
+COPY src/mqtt-kafka-connect /tmp/mqtt-kafka-connect
+RUN cd /tmp/mqtt-kafka-connect && \
+    mvn clean package && \
+    mkdir -p /usr/local/share/kafka-connect/plugins/mqtt-kafka-connect && \
+    cp target/mqtt-kafka-connect-1.0-jar-with-dependencies.jar /usr/local/share/kafka-connect/plugins/mqtt-kafka-connect/
+
+# -----------------------------
+# Build JDBC Connector with PostGIS patch
+# -----------------------------
+COPY src/own-jdbc-connector/postgis-support.patch /tmp/postgis-support.patch
+RUN cd /tmp && \
+    git clone https://github.com/confluentinc/kafka-connect-jdbc.git && \
+    cd kafka-connect-jdbc && \
+    git checkout v10.7.0 && \
+    git apply /tmp/postgis-support.patch && \
+    mvn clean package -DskipTests -Dcheckstyle.skip=true && \
+    mkdir -p /usr/local/share/kafka-connect/plugins/kafka-connect-jdbc && \
+    cp target/kafka-connect-jdbc-10.7.0.jar /usr/local/share/kafka-connect/plugins/kafka-connect-jdbc/
+
+# PostgreSQL JDBC Driver
+RUN wget https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.1/postgresql-42.7.1.jar -P /usr/local/share/kafka-connect/plugins/kafka-connect-jdbc/
+
+# -----------------------------
+# MongoDB Kafka Connector
+# -----------------------------
+RUN mkdir -p /usr/local/share/kafka-connect/plugins/mongodb && \
+    wget https://repo.maven.apache.org/maven2/org/mongodb/kafka/mongo-kafka-connect/1.10.0/mongo-kafka-connect-1.10.0-confluent.jar -O /usr/local/share/kafka-connect/plugins/mongodb/mongo-kafka-connect-1.10.0-confluent.jar && \
+    wget https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/4.9.1/mongodb-driver-core-4.9.1.jar -P /usr/local/share/kafka-connect/plugins/mongodb/ && \
+    wget https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-sync/4.9.1/mongodb-driver-sync-4.9.1.jar -P /usr/local/share/kafka-connect/plugins/mongodb/ && \
+    wget https://repo1.maven.org/maven2/org/mongodb/bson/4.9.1/bson-4.9.1.jar -P /usr/local/share/kafka-connect/plugins/mongodb/
+
+# -----------------------------
+# JMX Exporter Agent
+# -----------------------------
+RUN mkdir -p /usr/share/jmx_exporter && \
+    wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar -O /usr/share/jmx_exporter/jmx_prometheus_javaagent.jar
+
 COPY monitoring/kafka-connect.yml /usr/share/jmx_exporter/
 
-# Switch back to the original user (appuser)
+# -----------------------------
+# Set permissions and environment
+# -----------------------------
+RUN chown -R appuser:appuser /usr/local/share/kafka-connect/plugins /usr/share/jmx_exporter
+
 USER appuser
 
-# Default environment variables
 ENV CONNECT_PLUGIN_PATH="/usr/local/share/kafka-connect/plugins:/usr/share/java"
 ENV KAFKA_JMX_PORT=9100
 ENV JMX_PROMETHEUS_PORT=9100


### PR DESCRIPTION
This PR addresses [Issue #25](https://github.com/<tu-repo>/issues/25) by implementing a custom Docker image for Kafka Connect that includes all required plugins directly during the image build process. This simplifies deployment and removes the need for manual plugin setup.

Notably:
- The MongoDB Kafka connector (`mongo-kafka-connect-1.10.0-confluent.jar`) was retrieved from the official Maven repository:  
  https://repo.maven.apache.org/maven2/org/mongodb/kafka/mongo-kafka-connect/1.10.0/

With this setup, building the image (`kafnus-connect`) is all that's needed to have a ready-to-use Kafka Connect with:
- JDBC plugin for PostGIS
- MongoDB sink connector
- Custom SMT (`HeaderRouter`)
- MQTT source connector (temporary)

