### PR TITLE
Improve GitHub Actions test logs for better readability

### DIFF
--- a/.github/workflows/end2end_tests.yml
+++ b/.github/workflows/end2end_tests.yml
@@ -55,6 +55,20 @@ jobs:
           sudo mkdir -p /data/postgis
           sudo chown -R 999:999 /data/postgis
 
+      - name: Pre-pull required docker images
+        run: |
+          docker pull postgis/postgis:15-3.3
+          docker pull confluentinc/cp-kafka:7.9.0
+          docker pull telefonicaiot/fiware-orion
+          docker pull mongo:8.0
+          docker eclipse-mosquitto:latest
+          docker pull telefonicaiot/kafnus-connect
+
+      - name: Build kafnus-ngsi image
+        working-directory: ../kafnus-ngsi
+        run: |
+          docker build --no-cache -t kafnus-ngsi .
+      
       - name: Run end-to-end tests with pytest
         working-directory: tests_end2end/functional
         run: |

--- a/.github/workflows/end2end_tests.yml
+++ b/.github/workflows/end2end_tests.yml
@@ -61,7 +61,7 @@ jobs:
           docker pull confluentinc/cp-kafka:7.9.0
           docker pull telefonicaiot/fiware-orion
           docker pull mongo:8.0
-          docker eclipse-mosquitto:latest
+          docker pull eclipse-mosquitto:latest
           docker pull telefonicaiot/kafnus-connect
 
       - name: Build kafnus-ngsi image

--- a/.github/workflows/end2end_tests.yml
+++ b/.github/workflows/end2end_tests.yml
@@ -65,7 +65,7 @@ jobs:
           docker pull telefonicaiot/kafnus-connect
 
       - name: Build kafnus-ngsi image
-        working-directory: ../../kafnus-ngsi
+        working-directory: kafnus-ngsi
         run: |
           docker build --no-cache -t kafnus-ngsi .
       

--- a/.github/workflows/end2end_tests.yml
+++ b/.github/workflows/end2end_tests.yml
@@ -65,7 +65,7 @@ jobs:
           docker pull telefonicaiot/kafnus-connect
 
       - name: Build kafnus-ngsi image
-        working-directory: ../kafnus-ngsi
+        working-directory: ../../kafnus-ngsi
         run: |
           docker build --no-cache -t kafnus-ngsi .
       

--- a/tests_end2end/functional/conftest.py
+++ b/tests_end2end/functional/conftest.py
@@ -26,3 +26,15 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 from common_test import multiservice_stack
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """
+    Print a summary of the test results at the end of the test run.
+    """
+    terminalreporter.write_sep("=", "📋 Scenario Summary")
+    for report in terminalreporter.stats.get("passed", []):
+        if report.when == "call":
+            terminalreporter.write_line(f"✅ {report.nodeid}")
+    for report in terminalreporter.stats.get("failed", []):
+        if report.when == "call":
+            terminalreporter.write_line(f"❌ {report.nodeid}")


### PR DESCRIPTION
This PR improves the readability of the GitHub Actions logs during end-to-end test execution by:

- Moving `docker pull` and `docker build` steps outside the main test execution step, reducing noise in the logs.
- Adding a custom `pytest_terminal_summary` to print a clear and concise summary of all test scenarios at the end of the run.

These changes aim to separate the setup/build output from the actual test results, making it easier to identify which scenarios passed or failed.

Related to: [Add GitHub Action to run tests #15](https://github.com/<your-org-or-user>/<your-repo>/issues/15)