### PR TITLE
Recover lost warning

### DIFF
--- a/doc/01_installation.md
+++ b/doc/01_installation.md
@@ -56,9 +56,9 @@ The build process for Kafnus NGSI is defined in the [Dockerfile](/kafnus-ngsi/Do
 > ℹ️ No additional setup is required—this container is fully managed within the `docker compose` environment.
 
 > The `docker-compose.faust.yml` files specify the `image:` option for Kafnus NGSI.  
-
+>
 > If the image is not present locally (first time), Docker Compose will try to pull it from the registry (Docker Hub by default) and will show a warning if the image is not found.  
-
+> 
 > For now, this warning is expected and does not affect test execution, as images are built dynamically or local images are used depending on the environment.
 
 ---


### PR DESCRIPTION
Just a small fix to recover lost warning in doc.

```markdown
> The `docker-compose.faust.yml` files specify the `image:` option for Kafnus NGSI.  

> If the image is not present locally (first time), Docker Compose will try to pull it from the registry (Docker Hub by default) and will show a warning if the image is not found.  

> For now, this warning is expected and does not affect test execution, as images are built dynamically or local images are used depending on the environment.
```

It was lost and it is needed because kafnus-ngsi image is present in `docker-compose.faust.yml`:

```yaml
kafnus-ngsi:
    container_name: kafnus-ngsi
    build:
      context: ../kafnus-ngsi
      dockerfile: Dockerfile
    image: kafnus-ngsi
```