### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/end2end_tests.yml
+++ b/.github/workflows/end2end_tests.yml
@@ -1,5 +1,8 @@
 name: Run end-to-end tests
- 
+
+permissions:
+  contents: read
+
 on:
   push:
      branches:


### PR DESCRIPTION
Potential fix for [https://github.com/telefonicaid/kafnus/security/code-scanning/1](https://github.com/telefonicaid/kafnus/security/code-scanning/1)

To fix the problem, add a `permissions` key to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and does not perform any write operations (such as creating or modifying issues, pull requests, or repository contents), the minimal permission required is `contents: read`. This can be set at the workflow level (top-level, applying to all jobs) or at the job level (under `e2e-tests`). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made at the top of the file, after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
