### PR TITLE
Add out of order test

### DIFF
--- a/tests_end2end/functional/cases/004_lastdata/001_order/description.txt
+++ b/tests_end2end/functional/cases/004_lastdata/001_order/description.txt
@@ -1,0 +1,1 @@
+Test to verify that when sensor data messages arrive out of chronological order, the system correctly stores only the record with the latest TimeInstant for each entity

--- a/tests_end2end/functional/cases/004_lastdata/001_order/expected_pg.json
+++ b/tests_end2end/functional/cases/004_lastdata/001_order/expected_pg.json
@@ -1,0 +1,15 @@
+[
+    {
+    "table": "test.order_sensor_lastdata",
+    "rows": [
+        {"entityid": "Sensor3", "timeinstant": "2025-06-26T12:30:00Z", "entitytype": "Sensor", "temperature": 25.0, "fiwareservicepath": "/order"}
+    ]
+    },
+    {
+    "table": "test.order_sensor_lastdata",
+    "absent": [
+        {"entityid": "Sensor3", "timeinstant": "2025-06-26T12:10:00Z"},
+        {"entityid": "Sensor3", "timeinstant": "2025-06-26T12:20:00Z"}
+    ]
+    }
+]

--- a/tests_end2end/functional/cases/004_lastdata/001_order/input.json
+++ b/tests_end2end/functional/cases/004_lastdata/001_order/input.json
@@ -1,0 +1,67 @@
+{
+  "name": "out_of_order_test_case",
+  "fiware-service": "test",
+  "fiware-servicepath": "/order",
+  "subscriptions": {
+    "lastdata": {
+      "description": "Sensor:LASTDATA:order:lastdata:order",
+      "status": "active",
+      "subject": {
+        "entities": [
+          {
+            "idPattern": ".*",
+            "type": "Sensor"
+          }
+        ],
+        "condition": {
+          "attrs": ["TimeInstant"],
+          "alterationTypes": [
+            "entityUpdate",
+            "entityCreate",
+            "entityDelete"
+          ]
+        }
+      },
+      "notification": {
+        "mqttCustom": {
+          "url": "mqtt://mosquitto:1883",
+          "topic": "kafnus/${service}${servicePath}/raw_lastdata"
+        },
+        "attrs": [
+          "TimeInstant",
+          "temperature",
+          "alterationType"
+        ]
+      }
+    }
+  },
+  "updateEntities": [
+    {
+      "id": "Sensor3",
+      "type": "Sensor",
+      "TimeInstant": {
+        "type": "DateTime",
+        "value": "2025-06-26T12:30:00Z"
+      },
+      "temperature": {"value": 25.0, "type": "Float"}
+    },
+    {
+      "id": "Sensor3",
+      "type": "Sensor",
+      "TimeInstant": {
+        "type": "DateTime",
+        "value": "2025-06-26T12:10:00Z"
+      },
+      "temperature": {"value": 23.0, "type": "Float"}
+    },
+    {
+      "id": "Sensor3",
+      "type": "Sensor",
+      "TimeInstant": {
+        "type": "DateTime",
+        "value": "2025-06-26T12:20:00Z"
+      },
+      "temperature": {"value": 24.0, "type": "Float"}
+    }
+  ]
+}

--- a/tests_end2end/functional/cases/004_lastdata/001_order/setup.sql
+++ b/tests_end2end/functional/cases/004_lastdata/001_order/setup.sql
@@ -1,0 +1,13 @@
+-- Drop table
+DROP TABLE IF EXISTS test.order_sensor_lastdata;
+
+-- Create table
+CREATE TABLE IF NOT EXISTS test.order_sensor_lastdata (
+    recvtime TIMESTAMPTZ NOT NULL,
+    fiwareservicepath TEXT,
+    entityid TEXT,
+    entitytype TEXT,
+    timeinstant TIMESTAMPTZ,
+    temperature DOUBLE PRECISION,
+    CONSTRAINT order_sensor_lastdata_pkey PRIMARY KEY (entityid)
+);

--- a/tests_end2end/functional/cases/004_lastdata/002_delete/description.txt
+++ b/tests_end2end/functional/cases/004_lastdata/002_delete/description.txt
@@ -1,0 +1,1 @@
+Test delete an entity in lastdata flow


### PR DESCRIPTION
In this test, we verify the current behavior of the **lastdata** flow, which may change in the future.
In the first image, we can see that the Context Broker sends three notifications out of chronological order.
In the second image, we can see that only the most recent notification is forwarded.

**Note**: This functionality is implemented by **kafnus-ngsi**. The current JDBC connector from Confluent does not provide this capability.

**Raw topic** from the Context Broker to kafnus-ngsi:
<img width="1852" height="228" alt="imagen" src="https://github.com/user-attachments/assets/ade8b3a0-d4eb-442d-9e5c-3cc808765535" />

**Processed topic** from kafnus-ngsi to kafnus-connect:
<img width="1852" height="116" alt="imagen" src="https://github.com/user-attachments/assets/157dc9b4-20dc-4bf5-be5a-211be8102119" />