### PR TITLE
Add changes to test modified JDBC connector

### DIFF
--- a/docker/docker-compose.kafka.yml
+++ b/docker/docker-compose.kafka.yml
@@ -56,7 +56,10 @@ services:
 
   kafnus-connect:
     container_name: kafnus-connect
-    image: telefonicaiot/kafnus-connect
+    build:
+      context: ../kafnus-connect
+      dockerfile: Dockerfile
+    image: kafnus-connect
     ports:
       - "8083:8083"
       - "9100:9100"

--- a/kafnus-connect/Dockerfile
+++ b/kafnus-connect/Dockerfile
@@ -77,7 +77,7 @@ RUN cd /tmp/mqtt-kafka-connect && \
 RUN cd /tmp && \
     git clone https://github.com/telefonicaid/kafka-connect-jdbc-postgis.git && \
     cd kafka-connect-jdbc-postgis && \
-    git checkout task/add_postgis_10_7_0 && \
+    git checkout task/add_upsert && \
     mvn clean package -DskipTests -Dcheckstyle.skip=true && \
     mkdir -p /usr/local/share/kafnus-connect/plugins/kafka-connect-jdbc && \
     cp target/kafka-connect-jdbc-10.7.0.jar /usr/local/share/kafnus-connect/plugins/kafka-connect-jdbc/

--- a/sinks/pg-sink-lastdata.json
+++ b/sinks/pg-sink-lastdata.json
@@ -9,6 +9,7 @@
     "connection.password": "postgres",
     
     "insert.mode": "upsert",
+    "update.if.newer.field": "timeinstant",
     "pk.mode": "record_key",
     "pk.fields": "entityid",
     "table.name.format": "test.${topic}",


### PR DESCRIPTION
Removed the `timeinstant` filtering logic from the processor to fully delegate out-of-order record handling to the new `update.if.newer.field` feature in the JDBC connector.  
This change allows us to test and validate that the comparison is correctly performed at the database layer.

Related Issue #58 