### PR TITLE
Update Kafnus NGSI Documentation to Align with Node.js Implementation

### DIFF
--- a/.github/workflows/end2end_tests.yml
+++ b/.github/workflows/end2end_tests.yml
@@ -58,6 +58,7 @@ jobs:
           sudo mkdir -p /data/postgis
           sudo chown -R 999:999 /data/postgis
 
+      # FIXME: mosquitto and telefonicaiot/kafnus-connect:http will be removed
       - name: Pre-pull required docker images
         run: |
           docker pull postgis/postgis:15-3.3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It processes NGSI notifications from the Context Broker (CB) and stores them in 
   Temporary entry point for CB notifications (to be removed once CB supports native Kafka output).
 
 - ⚙️ **Kafnus NGSI**  
-  Using **Faust** library, transforms raw notifications into structured events. Each data flow (historic, lastdata, mutable, etc.) is handled by an independent agent.
+  Node.js service that transforms raw notifications into structured events. Each data flow (historic, lastdata, mutable, etc.) is handled by an independent agent.
 
 - 🔄 **Kafnus Connect**  
   Custom image of Kafka Connect with plugins integrated. Persists processed messages to:
@@ -56,5 +56,6 @@ Complete documentation is available in the [`doc/`](./doc) directory:
 
 - Docker + docker compose
 - Java 11+
+- Node.js 20+ (for Kafnus NGSI)
 - Python 3.11+ (for tests)
 - Maven

--- a/doc/00_overview.md
+++ b/doc/00_overview.md
@@ -16,7 +16,7 @@ Kafnus offers a scalable, resilient, and modular system to process NGSI notifica
 
 ### 🧠 Processing Layer
 - **Kafnus NGSI Stream Processor**  
-  A Python-based service that enriches and transforms raw notifications into structured messages. Each flow (e.g., `historic`, `lastdata`, `mutable`) is managed by a dedicated Kafnus NGSI agent.
+  A Node.js-based service that enriches and transforms raw notifications into structured messages. Each flow (e.g., `historic`, `lastdata`, `mutable`) is managed by a dedicated Kafnus NGSI agent.
 
 ### 💾 Persistence Layer
 - **Kafnus Connect (JDBC + MongoDB)**  
@@ -66,7 +66,7 @@ Kafnus offers a scalable, resilient, and modular system to process NGSI notifica
 
 ## 📂 Source Structure (simplified)
 
-- `kafnus-ngsi/`: Kafnus NGSI logic and tests  
+- `kafnus-ngsi-js/`: Kafnus NGSI logic and tests  
 - `docker/`: docker-compose files and scripts  
 - `monitoring/`: Prometheus + Grafana setup  
 - `tests_end2end/`: E2E test cases and framework  

--- a/doc/01_installation.md
+++ b/doc/01_installation.md
@@ -34,22 +34,22 @@ This directory is automatically populated during the image build, based on the l
 
 ## 2. ⚙️ Kafnus NGSI Worker Image
 
-The **Kafnus NGSI stream processor** is also containerized and automatically built during `docker-up.sh` execution. This ensures the worker is:
+The **Kafnus NGSI stream processor** (Node.js version) is also containerized and automatically built during `docker-up.sh` execution. This ensures the worker is:
 
-- Compiled with the correct Python version and dependencies
+- Built with the correct Node.js version and dependencies
 - Isolated from the host system
 - Ready to run with the default command:  
 
 ```bash
-faust -A stream_processor worker -l info
+npm install
+npm start
 ```
 
 The source code lives in:
 
 ```
-kafnus-ngsi/src/
+kafnus-ngsi-js/
 ```
-
 
 The build process for Kafnus NGSI is defined in the [Dockerfile](/kafnus-ngsi/Dockerfile), which installs all dependencies and starts the worker.
 
@@ -63,7 +63,7 @@ The build process for Kafnus NGSI is defined in the [Dockerfile](/kafnus-ngsi/Do
 
 ---
 
-## 3. 🐍 Python Environment Setup
+## 3. 🐍 Python Environment Setup (for tests)
 
 > ✅ Requires **Python 3.11**
 

--- a/doc/02_architecture.md
+++ b/doc/02_architecture.md
@@ -72,7 +72,7 @@ Detailed diagram showing all services and flows in the PostGIS variant:
 
 ### 🧠 Processing – Kafnus NGSI
 
-- Written in Python using [Faust](https://faust.readthedocs.io/)
+- Written in Node.js (previously Python/Faust, now deprecated)
 - Processes raw NGSIv2 notifications
 - Applies logic per flow:
   - `historic`: all events

--- a/doc/03_operational_guide.md
+++ b/doc/03_operational_guide.md
@@ -42,7 +42,7 @@ Confirm these are **Up (healthy)**:
 ```plaintext
 kafka           ← Kafka broker
 kafnus-connect  ← Kafnus Connect
-kafnus-ngsi     ← Kafnus NGSI
+kafnus-ngsi-js     ← Kafnus NGSI (Node.js)
 orion           ← Context Broker
 mongo           ← MongoDB
 mosquitto       ← MQTT broker

--- a/doc/04_docker.md
+++ b/doc/04_docker.md
@@ -25,7 +25,7 @@ Custom Dockerfiles are located in their respective component directories:
 kafnus-connect/
 └── Dockerfile
 
-kafnus-ngsi/
+kafnus-ngsi-js/
 └── Dockerfile
 ```
 
@@ -65,7 +65,7 @@ Stops the same services and removes volumes & orphan containers:
 The Docker Compose setup relies on two custom images:
 
 - **Kafnus Connect** is built using `kafnus-connect/Dockerfile`, which includes all required connectors and plugins during the image build process.
-- **Kafnus NGSI** is built using `kafnus-ngsi/Dockerfile`, which includes the stream processing app and all dependencies.
+- **Kafnus NGSI** is built using `kafnus-ngsi-js/Dockerfile`, which includes the Node.js stream processing app and all dependencies.
 
 Both images are automatically built via `docker-up.sh`, so you don't need to build them manually unless debugging or developing.
 

--- a/doc/09_scaling.md
+++ b/doc/09_scaling.md
@@ -303,7 +303,6 @@ After changing:
 | Component             | Scale Type   | Strategy                            |
 |----------------------|--------------|-------------------------------------|
 | Kafka Topics          | Horizontal   | Increase partitions                 |
-| kafnus-ngsi (Python)  | Horizontal   | More pods (`--concurrency=1`)       |
 | kafnus-ngsi (Node.js) | Horizontal   | More pods, 1 process per partition  |
 | kafnus-ngsi (Java)    | Vertical     | More CPU/RAM per instance, threads  |
 

--- a/docker/docker-compose.kafka.yml
+++ b/docker/docker-compose.kafka.yml
@@ -62,7 +62,7 @@ services:
     #   context: ../kafnus-connect
     #   dockerfile: Dockerfile
     # image: kafnus-connect
-    image: telefonicaiot/kafnus-connect:http
+    image: telefonicaiot/kafnus-connect:http # FIXME: ¿?
     ports:
       - "8083:8083"
       - "9100:9100"
@@ -89,7 +89,5 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-      #mosquitto:
-      #  condition: service_healthy
     networks:
       - kafka-postgis-net

--- a/docker/docker-compose.ngsi.yml
+++ b/docker/docker-compose.ngsi.yml
@@ -58,18 +58,14 @@ services:
     container_name: kafnus-ngsi
     build:
       context: ../kafnus-ngsi-js
-      #context: ../kafnus-ngsi
       dockerfile: Dockerfile
-    image: kafnus-ngsi # telefonicaiot/kafnus-ngsi (at some moment we will use dockerhub image but by the moment kafnus-ngsi is evolving fast so we build in GitAction directly :)
-    #image: telefonicaiot/kafnus-ngsi:js
+    image: kafnus-ngsi # FIXME: telefonicaiot/kafnus-ngsi (at some moment we will use dockerhub image but by the moment kafnus-ngsi is evolving fast so we build in GitAction directly :)
     depends_on:
       kafka:
         condition: service_healthy
       create-topics:
         condition: service_completed_successfully
     environment:
-      - FAUST_BROKER=kafka://kafka:9092
-      #- KAFNUS_NGSI_KAFKA_BROKER=kafka://kafka:9092
       - KAFNUS_NGSI_KAFKA_BROKER=kafka:9092
       - KAFNUS_NGSI_METRICS_PORT=8000
       - KAFNUS_NGSI_DEFAULT_TZ=UTC
@@ -77,10 +73,8 @@ services:
     networks:
       - kafka-postgis-net
     ports:
-    #  - "6066:6066"  # Faust web
       # Monitoring
       - "8000:8000"  # Prometheus
-    #command: sh -c "faust -A stream_processor worker -l ${KAFNUS_NGSI_LOG_LEVEL:-info}"
 
 networks:
   kafka-postgis-net:

--- a/docker/docker-compose.orion.yml
+++ b/docker/docker-compose.orion.yml
@@ -54,6 +54,7 @@ services:
     networks:
       - kafka-postgis-net
 
+  # FIXME: at some point, CB will be capable of notify Kafka directly
   mosquitto:
     image: eclipse-mosquitto:latest
     container_name: mosquitto

--- a/docker/docker-compose.postgis.yml
+++ b/docker/docker-compose.postgis.yml
@@ -26,6 +26,7 @@ services:
   iot-postgis:
     container_name: iot-postgis
     hostname: iot-postgis
+    # Deafult env variables will be used if not specify in .env
     image: ${KAFNUS_POSTGIS_IMAGE:-postgis/postgis:15-3.3}
     volumes:
       - ${KAFNUS_DBPATH_POSTGIS:-/data/postgis}:/var/lib/postgresql/data

--- a/kafnus-ngsi-js/README.md
+++ b/kafnus-ngsi-js/README.md
@@ -1,7 +1,10 @@
 # kafnus-ngsi-js
 
-Copy or rename renombra `.env.example` a `.env` with your Kafka credentials and exec:
+To use the Node.js version of Kafnus NGSI, copy or rename `.env.example` to `.env` and provide your Kafka credentials. Then install dependencies and start the service:
 
 ```bash
 npm install
 npm start
+```
+
+For more details, refer to the documentation in the main project or the `doc/` directory.

--- a/kafnus-ngsi/README.md
+++ b/kafnus-ngsi/README.md
@@ -1,0 +1,4 @@
+# ⚠️ Deprecation Notice
+
+**The Python implementation of Kafnus NGSI is deprecated.**
+The project has migrated to a new Node.js version (`kafnus-ngsi-js`), which is now the recommended and supported implementation. The Python version will be removed in a future release. Please use the Node.js version for all new developments and deployments.


### PR DESCRIPTION
This PR updates all documentation related to Kafnus NGSI to reflect the migration from the deprecated Python/Faust implementation to the current Node.js version. The following changes are included:

- All references to Python, Faust, and related files have been replaced with Node.js terminology, file paths, and function names.
- The main entry point, logging examples, and code snippets now match the Node.js codebase (`kafnus-ngsi-js/index.js`, `handleEntityCb.js`, `ngsiUtils.js`).
- Requirements and installation instructions have been updated to require Node.js for Kafnus NGSI, with Python only needed for tests.
- Architecture, operational, and Docker documentation now clarify that Kafnus NGSI is Node.js-based and the Python version is deprecated.

Closes #67.