### PR TITLE
Implement final type handling policy in inferFieldType

### DIFF
--- a/kafnus-ngsi/lib/utils/ngsiUtils.js
+++ b/kafnus-ngsi/lib/utils/ngsiUtils.js
@@ -123,13 +123,13 @@ function inferFieldType(name, value, attrType = null) {
 
     // 0. Null or undefined values: return string with null value
     if (value === null || value === undefined) {
-        return ['string', null]; // this could be improved with type mapping
+        return ['string', null];
     }
 
     // 1. Handle special attribute types
     if (attrType) {
         // Geospatial types
-        if (attrType.startsWith('geo:')) {
+        if (attrType == "geo:json") {
             return ['geometry', value];
         }
 
@@ -151,16 +151,6 @@ function inferFieldType(name, value, attrType = null) {
                 return ['string', String(value)];
             }
         }
-
-        // JSON or structured values: serialize to string
-        if (['json', 'StructuredValue'].includes(attrType)) {
-            try {
-                return ['string', JSON.stringify(value)];
-            } catch (err) {
-                logger.warn(`Error serializing '${name}' as JSON: ${err}`);
-                return ['string', String(value)];
-            }
-        }
     }
 
     // 2. If not a special type, but value is a string → treat as string
@@ -173,19 +163,7 @@ function inferFieldType(name, value, attrType = null) {
         return ['boolean', value];
     }
 
-    // Integer handling: choose int32 or int64 based on range
-    if (Number.isInteger(value)) {
-        // Safe int32
-        if (value >= -(2 ** 31) && value <= 2 ** 31 - 1) return ['int32', value];
-
-        // Safe int64 (check safe integer range)
-        if (Number.isSafeInteger(value)) return ['int64', value];
-
-        // Out of safe integer → treat as double
-        return ['double', value];
-    }
-
-    // Floating point numbers
+    // Number handling: return as double (type  in JS is always float64)
     if (typeof value === 'number') {
         return ['double', value];
     }
@@ -203,7 +181,6 @@ function inferFieldType(name, value, attrType = null) {
     // 4. All other cases: treat as string
     return ['string', String(value)];
 }
-
 
 // -----------------
 // Kafka Schema Builder

--- a/tests_end2end/functional/cases/003_errors/001_non_transient/expected_pg.json
+++ b/tests_end2end/functional/cases/003_errors/001_non_transient/expected_pg.json
@@ -32,7 +32,7 @@
     "rows": [
       {
         "query": { "contains": "INSERT INTO \"tests\".\"test\".\"access_errors\"" },
-        "error": { "contains": "ERROR: column \"bool_col\" is of type boolean but expression is of type integer"}
+        "error": { "contains": "ERROR: column \"bool_col\" is of type boolean but expression is of type double precision"}
       },
       {
         "query": { "contains": "INSERT INTO \"tests\".\"test\".\"access_errors\"" },
@@ -44,8 +44,12 @@
       },
       {
         "query": { "contains": "INSERT INTO \"tests\".\"test\".\"access_errors\"" },
+        "error": { "regex": "ERROR: null value in column .*double_not_null.*violates.*not[- ]?null constraint" }
+      },
+      {
+        "query": { "contains": "INSERT INTO \"tests\".\"test\".\"access_errors\"" },
         "error": { "contains": "ERROR: duplicate key value violates unique constraint \"access_errors_pkey\"" }
-      }
+     }
     ]
   }
 ]

--- a/tests_end2end/functional/cases/003_errors/001_non_transient/input.json
+++ b/tests_end2end/functional/cases/003_errors/001_non_transient/input.json
@@ -21,6 +21,7 @@
           "text_col",
           "not_null_col",
           "int_col",
+          "double_not_null",
           "averagestay"
         ]
       }
@@ -32,27 +33,23 @@
       "type": "Errors",
       "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:35:00Z" },
       "averagestay": { "type": "Number", "value": 15 },
-      "not_null_col": { "type": "Text", "value": "not_null" }
+      "not_null_col": { "type": "Text", "value": "not_null" },
+      "double_not_null": { "type": "Number", "value": 1.1 }
     },
     {
       "id": "NPO-test",
       "type": "Errors",
       "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:40:00Z" },
-      "bool_col": { "type": "Number", "value": 67 }
+      "bool_col": { "type": "Number", "value": 67 },
+      "double_not_null": { "type": "Number", "value": 1.1 }
     },
     {
       "id": "NPO-test",
       "type": "Errors",
       "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:45:00Z" },
       "bool_col": { "type": "Boolean", "value": true },
-      "text_col": { "type": "Text", "value": { "a": 1, "b": 2 } }
-    },
-    {
-      "id": "NPO-test",
-      "type": "Errors",
-      "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:45:00Z" },
-      "bool_col": { "type": "Boolean", "value": true },
-      "text_col": { "type": "Text", "value": null }
+      "text_col": { "type": "Text", "value": { "a": 1, "b": 2 } },
+      "double_not_null": { "type": "Number", "value": 1.1 }
     },
     {
       "id": "NPO-test",
@@ -60,7 +57,8 @@
       "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:50:00Z" },
       "bool_col": { "type": "Boolean", "value": true },
       "text_col": { "type": "Text", "value": "text" },
-      "not_null_col": { "type": "Text", "value": null }
+      "not_null_col": { "type": "Text", "value": null },
+      "double_not_null": { "type": "Number", "value": 1.1 }
     },
     {
       "id": "NPO-test",
@@ -69,7 +67,18 @@
       "bool_col": { "type": "Boolean", "value": true },
       "text_col": { "type": "Text", "value": "text" },
       "not_null_col": { "type": "Text", "value": "not_null" },
-      "int_col": { "type": "Text", "value": "abierto" }
+      "int_col": { "type": "Text", "value": "abierto" },
+      "double_not_null": { "type": "Number", "value": 1.1 }
+    },
+    {
+      "id": "NPO-test",
+      "type": "Errors",
+      "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:56:00Z" },
+      "bool_col": { "type": "Boolean", "value": true },
+      "text_col": { "type": "Text", "value": "text" },
+      "not_null_col": { "type": "Text", "value": "not_null" },
+      "int_col": { "type": "Text", "value": 1 },
+      "double_not_null": { "type": "Number", "value": null }
     },
     {
       "id": "NPO-test",
@@ -79,13 +88,15 @@
       "text_col": { "type": "Text", "value": "text" },
       "not_null_col": { "type": "Text", "value": "not_null" },
       "int_col": { "type": "Number", "value": 1 },
-      "averagestay": { "type": "Number", "value": 17 }
+      "averagestay": { "type": "Number", "value": 17 },
+      "double_not_null": { "type": "Number", "value": 1.1 }
     },
     {
       "id": "NPO-test",
       "type": "Errors",
       "timeinstant": { "type": "DateTime", "value": "2025-05-05T11:35:00Z" },
-      "averagestay": { "type": "Number", "value": 16 }
+      "averagestay": { "type": "Number", "value": 16 },
+      "double_not_null": { "type": "Number", "value": 1.1 }
     }
   ]
 }

--- a/tests_end2end/functional/cases/003_errors/001_non_transient/setup.sql
+++ b/tests_end2end/functional/cases/003_errors/001_non_transient/setup.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS test.access_errors (
     text_col TEXT,            -- ❌
     not_null_col TEXT NOT NULL, -- ❌
     int_col INTEGER,                   -- ❌
+    double_not_null DOUBLE PRECISION NOT NULL,                   -- ❌
     averagestay DOUBLE PRECISION,     -- ✅
 
     CONSTRAINT access_errors_pkey PRIMARY KEY (timeinstant, entityid)


### PR DESCRIPTION
Finalizes the type inference rules in `inferFieldType` for Kafnus NGSI, handling `geo:json`, `DateTime/ISO8601`, JS-native types, and nulls according to the agreed policy. Resolves issue #59.