### PR TITLE
Increase max retries from 1 to 2 in http-sink.json

### DIFF
--- a/tests_end2end/sinks/http-sink.json
+++ b/tests_end2end/sinks/http-sink.json
@@ -19,7 +19,7 @@
     "errors.deadletterqueue.topic.replication.factor": "1",
     "errors.log.enable": false,
     "errors.log.include.messages": false,
-    "max.retries": "1",
+    "max.retries": "2",
     "retry.backoff.ms": "500"
   }
 }


### PR DESCRIPTION
For cases when backend is in internal error: then a retry is consumed and no refresh token happens