### PR TITLE
Task/add virtuoso sink

### DIFF
--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -20,7 +20,7 @@
 const { createConsumerAgent } = require('./sharedConsumerAgentFactory');
 const { getFiwareContext } = require('../utils/ngsiUtils');
 const { safeProduce } = require('../utils/handleEntityCb');
-const { messagesProcessed, processingTime } = require('../utils/admin');
+const { recordFlowProcessing } = require('../utils/admin');
 const { config } = require('../../kafnusConfig');
 const { getGrafoName, buildSparqlForEntity } = require('../utils/virtuosoUtils');
 const Kafka = require('@confluentinc/kafka-javascript');
@@ -96,8 +96,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
                 logger.error(`[sgtr-virtuoso] Error processing event: ${err?.stack || err}, offset NOT committed`);
             } finally {
                 const duration = (Date.now() - start) / 1000;
-                messagesProcessed.labels({ flow: 'sgtr_virtuoso' }).inc();
-                processingTime.labels({ flow: 'sgtr_virtuoso' }).set(duration);
+                recordFlowProcessing('sgtr-virtuoso', fiwareService, duration, processingResult);
             }
         }
     });

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -37,6 +37,8 @@ async function startVirtuosoConsumerAgent(logger, producer) {
         producer,
         onData: async (msg) => {
             const start = Date.now();
+            let processingResult = 'success';
+            let fiwareService = 'default';
             const k = msg.key?.toString() || '';
             const rawValue = msg.value?.toString() || '';
 
@@ -53,24 +55,25 @@ async function startVirtuosoConsumerAgent(logger, producer) {
                 }
 
                 logger.info('[sgtr-virtuoso] message: %j', message);
+                fiwareService = getFiwareContext(msg.headers, message).service;
 
                 const dataList = Array.isArray(message.data) ? message.data : [];
 
                 for (const entityObjectOriginal of dataList) {
                     const entityObject = JSON.parse(JSON.stringify(entityObjectOriginal));
-                    const { fiwareService } = getFiwareContext(msg.headers, message);
 
-                    logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(fiwareService, null, 2));
+                    const service = fiwareService;
+                    logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
                     logger.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
-                    const graphUri = getGrafoName(fiwareService);
+                    const graphUri = getGrafoName(service);
 
-                    const sparql = buildSparqlForEntity(graphUri, fiwareService, entityObject);
+                    const sparql = buildSparqlForEntity(graphUri, service, entityObject);
 
                     logger.debug('[sgtr-virtuoso] sparql:\n%s', sparql);
 
                     const outHeaders = [{ key: 'content-type', value: Buffer.from('application/sparql-update') }];
                     if (config.graphql.outputTopicByService) {
-                        outputTopic = config.ngsi.prefix + fiwareService + '_virtuoso_http' + config.ngsi.suffix;
+                        outputTopic = config.ngsi.prefix + service + '_virtuoso_http' + config.ngsi.suffix;
                     } else {
                         outputTopic = config.ngsi.prefix + 'virtuoso_http' + config.ngsi.suffix;
                     }

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+ *
+ * This file is part of kafnus
+ *
+ * kafnus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * kafnus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with kafnus. If not, see http://www.gnu.org/licenses/.
+ */
+
+const { createConsumerAgent } = require('./sharedConsumerAgentFactory');
+const { getFiwareContext } = require('../utils/ngsiUtils');
+const { safeProduce } = require('../utils/handleEntityCb');
+const { messagesProcessed, processingTime } = require('../utils/admin');
+const { config } = require('../../kafnusConfig');
+const { getGrafoName, buildSparqlForEntity } = require('../utils/virtuosoUtils');
+const Kafka = require('@confluentinc/kafka-javascript');
+
+async function startVirtuosoConsumerAgent(logger, producer) {
+    const topic = config.ngsi.prefix + 'raw_sgtr';
+    let outputTopic;
+    const groupId = 'ngsi-processor-sgtr-virtuoso';
+
+    const consumer = await createConsumerAgent(logger, {
+        groupId,
+        topic,
+        producer,
+        onData: async (msg) => {
+            const start = Date.now();
+            const k = msg.key?.toString() || '';
+            const rawValue = msg.value?.toString() || '';
+
+            logger.info(`[sgtr-virtuoso] key=${k} value=${rawValue}`);
+
+            try {
+                let message;
+                try {
+                    message = JSON.parse(rawValue);
+                } catch (e) {
+                    logger.warn('[sgtr-virtuoso] Invalid JSON, committing: %s', e.message);
+                    consumer.commitMessage(msg);
+                    return;
+                }
+
+                logger.info('[sgtr-virtuoso] message: %j', message);
+
+                const dataList = Array.isArray(message.data) ? message.data : [];
+
+                for (const entityObjectOriginal of dataList) {
+                    const entityObject = JSON.parse(JSON.stringify(entityObjectOriginal));
+                    const { service } = getFiwareContext(msg.headers, message);
+
+                    logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
+                    logger.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
+                    const graphUri = getGrafoName(service);
+
+                    const sparql = buildSparqlForEntity(graphUri, service, entityObject);
+
+                    logger.debug('[sgtr-virtuoso] sparql:\n%s', sparql);
+
+                    const outHeaders = [{ key: 'content-type', value: Buffer.from('application/sparql-update') }];
+                    if (config.graphql.outputTopicByService) {
+                        outputTopic = config.ngsi.prefix + service + '_virtuoso_http' + config.ngsi.suffix;
+                    } else {
+                        outputTopic = config.ngsi.prefix + 'virtuoso_http' + config.ngsi.suffix;
+                    }
+                    await safeProduce(producer, [
+                        outputTopic,
+                        null,
+                        Buffer.from(sparql),
+                        null,
+                        Date.now(),
+                        null,
+                        outHeaders
+                    ]);
+
+                    logger.info('[sgtr-virtuoso] Sent to %j | sparql %j', outputTopic, sparql);
+                }
+
+                consumer.commitMessage(msg);
+            } catch (err) {
+                if (err?.code === Kafka.CODES.ERRORS.ERR__QUEUE_FULL) {
+                    throw err;
+                }
+
+                logger.error(`[sgtr-virtuoso] Error processing event: ${err?.stack || err}, offset NOT committed`);
+            } finally {
+                const duration = (Date.now() - start) / 1000;
+                messagesProcessed.labels({ flow: 'sgtr_virtuoso' }).inc();
+                processingTime.labels({ flow: 'sgtr_virtuoso' }).set(duration);
+            }
+        }
+    });
+
+    return consumer;
+}
+
+module.exports = startVirtuosoConsumerAgent;

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -26,6 +26,7 @@ const { getGrafoName, buildSparqlForEntity } = require('../utils/virtuosoUtils')
 const Kafka = require('@confluentinc/kafka-javascript');
 
 async function startVirtuosoConsumerAgent(logger, producer) {
+    // TDB: define another raw topic for this consumer
     const topic = config.ngsi.prefix + 'raw_sgtr';
     let outputTopic;
     const groupId = 'ngsi-processor-sgtr-virtuoso';

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -58,19 +58,19 @@ async function startVirtuosoConsumerAgent(logger, producer) {
 
                 for (const entityObjectOriginal of dataList) {
                     const entityObject = JSON.parse(JSON.stringify(entityObjectOriginal));
-                    const { service } = getFiwareContext(msg.headers, message);
+                    const { fiwareService } = getFiwareContext(msg.headers, message);
 
-                    logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
+                    logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(fiwareService, null, 2));
                     logger.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
-                    const graphUri = getGrafoName(service);
+                    const graphUri = getGrafoName(fiwareService);
 
-                    const sparql = buildSparqlForEntity(graphUri, service, entityObject);
+                    const sparql = buildSparqlForEntity(graphUri, fiwareService, entityObject);
 
                     logger.debug('[sgtr-virtuoso] sparql:\n%s', sparql);
 
                     const outHeaders = [{ key: 'content-type', value: Buffer.from('application/sparql-update') }];
                     if (config.graphql.outputTopicByService) {
-                        outputTopic = config.ngsi.prefix + service + '_virtuoso_http' + config.ngsi.suffix;
+                        outputTopic = config.ngsi.prefix + fiwareService + '_virtuoso_http' + config.ngsi.suffix;
                     } else {
                         outputTopic = config.ngsi.prefix + 'virtuoso_http' + config.ngsi.suffix;
                     }

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -39,6 +39,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
             const start = Date.now();
             let processingResult = 'success';
             let fiwareService = 'default';
+            let graphName = null;
             const k = msg.key?.toString() || '';
             const rawValue = msg.value?.toString() || '';
 
@@ -56,7 +57,10 @@ async function startVirtuosoConsumerAgent(logger, producer) {
 
                 logger.info('[sgtr-virtuoso] message: %j', message);
                 fiwareService = getFiwareContext(msg.headers, message).service;
-
+                const fiwareContext = getFiwareContext(msg.headers, message);
+                fiwareService = fiwareContext.service;
+                graphName = fiwareContext.graphname;
+                logger.info('[sgtr-virtuoso] fiware-service: %j graphname: %j', fiwareService, graphName);
                 const dataList = Array.isArray(message.data) ? message.data : [];
 
                 for (const entityObjectOriginal of dataList) {
@@ -65,7 +69,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
                     const service = fiwareService;
                     logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
                     logger.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
-                    const graphUri = getGrafoName(service);
+                    const graphUri = getGrafoName(graphname);
 
                     const sparql = buildSparqlForEntity(graphUri, service, entityObject);
 

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -69,7 +69,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
                     const service = fiwareService;
                     logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
                     logger.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
-                    const graphUri = getGrafoName(graphname);
+                    const graphUri = getGrafoName(graphName);
 
                     const sparql = buildSparqlForEntity(graphUri, service, entityObject);
 

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -92,6 +92,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
 
                 consumer.commitMessage(msg);
             } catch (err) {
+                processingResult = 'error';
                 if (err?.code === Kafka.CODES.ERRORS.ERR__QUEUE_FULL) {
                     throw err;
                 }

--- a/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/virtuosoConsumerAgent.js
@@ -23,15 +23,16 @@ const { safeProduce } = require('../utils/handleEntityCb');
 const { recordFlowProcessing } = require('../utils/admin');
 const { config } = require('../../kafnusConfig');
 const { getGrafoName, buildSparqlForEntity } = require('../utils/virtuosoUtils');
+const logger = require('../utils/logger');
 const Kafka = require('@confluentinc/kafka-javascript');
 
-async function startVirtuosoConsumerAgent(logger, producer) {
+async function startVirtuosoConsumerAgent(log, producer) {
     // TDB: define another raw topic for this consumer
     const topic = config.ngsi.prefix + 'raw_sgtr';
     let outputTopic;
     const groupId = 'ngsi-processor-sgtr-virtuoso';
 
-    const consumer = await createConsumerAgent(logger, {
+    const consumer = await createConsumerAgent(log, {
         groupId,
         topic,
         producer,
@@ -40,40 +41,47 @@ async function startVirtuosoConsumerAgent(logger, producer) {
             let processingResult = 'success';
             let fiwareService = 'default';
             let graphName = null;
+            let currentlog = null;
             const k = msg.key?.toString() || '';
             const rawValue = msg.value?.toString() || '';
 
-            logger.info(`[sgtr-virtuoso] key=${k} value=${rawValue}`);
+            log.info(`[sgtr-virtuoso] key=${k} value=${rawValue}`);
 
             try {
                 let message;
                 try {
                     message = JSON.parse(rawValue);
                 } catch (e) {
-                    logger.warn('[sgtr-virtuoso] Invalid JSON, committing: %s', e.message);
+                    log.warn('[sgtr-virtuoso] Invalid JSON, committing: %s', e.message);
                     consumer.commitMessage(msg);
                     return;
                 }
 
-                logger.info('[sgtr-virtuoso] message: %j', message);
-                fiwareService = getFiwareContext(msg.headers, message).service;
+                log.info('[sgtr-virtuoso] message: %j', message);
                 const fiwareContext = getFiwareContext(msg.headers, message);
                 fiwareService = fiwareContext.service;
                 graphName = fiwareContext.graphname;
-                logger.info('[sgtr-virtuoso] fiware-service: %j graphname: %j', fiwareService, graphName);
+                log.info('[sgtr-virtuoso] fiware-service: %j graphname: %j', fiwareService, graphName);
+                const configContext = {
+                    op: 'virtuosoConsumer',
+                    corr: fiwareContext.correlator,
+                    service: fiwareContext.service,
+                    subservice: fiwareContext.servicepath
+                };
+                currentlog = logger.createChildLogger(configContext);
                 const dataList = Array.isArray(message.data) ? message.data : [];
 
                 for (const entityObjectOriginal of dataList) {
                     const entityObject = JSON.parse(JSON.stringify(entityObjectOriginal));
 
                     const service = fiwareService;
-                    logger.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
-                    logger.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
+                    currentlog.debug('[sgtr-virtuoso] fiware-service:%s', JSON.stringify(service, null, 2));
+                    currentlog.debug('[sgtr-virtuoso] entityObject:\n%s', JSON.stringify(entityObject, null, 2));
                     const graphUri = getGrafoName(graphName);
 
                     const sparql = buildSparqlForEntity(graphUri, service, entityObject);
 
-                    logger.debug('[sgtr-virtuoso] sparql:\n%s', sparql);
+                    currentlog.debug('[sgtr-virtuoso] sparql:\n%s', sparql);
 
                     const outHeaders = [{ key: 'content-type', value: Buffer.from('application/sparql-update') }];
                     if (config.graphql.outputTopicByService) {
@@ -91,7 +99,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
                         outHeaders
                     ]);
 
-                    logger.info('[sgtr-virtuoso] Sent to %j | sparql %j', outputTopic, sparql);
+                    currentlog.info('[sgtr-virtuoso] Sent to %j | sparql %j', outputTopic, sparql);
                 }
 
                 consumer.commitMessage(msg);
@@ -101,7 +109,7 @@ async function startVirtuosoConsumerAgent(logger, producer) {
                     throw err;
                 }
 
-                logger.error(`[sgtr-virtuoso] Error processing event: ${err?.stack || err}, offset NOT committed`);
+                currentlog.error(`[sgtr-virtuoso] Error processing event: ${err?.stack || err}, offset NOT committed`);
             } finally {
                 const duration = (Date.now() - start) / 1000;
                 recordFlowProcessing('sgtr-virtuoso', fiwareService, duration, processingResult);

--- a/kafnus-ngsi/lib/kafnus-ngsi.js
+++ b/kafnus-ngsi/lib/kafnus-ngsi.js
@@ -28,6 +28,7 @@ const startMutableConsumerAgent = require('./consumerAgents/mutableConsumerAgent
 const startErrorsConsumerAgent = require('./consumerAgents/errorsConsumerAgent');
 const startMongoConsumerAgent = require('./consumerAgents/mongoConsumerAgent');
 const startSgtrConsumerAgent = require('./consumerAgents/sgtrConsumerAgent');
+const startVirtuosoConsumerAgent = require('./consumerAgents/virtuosoConsumerAgent');
 
 const { startAdminServer } = require('./utils/admin');
 
@@ -53,7 +54,8 @@ async function main() {
             startMutableConsumerAgent(log, producer),
             startErrorsConsumerAgent(log, producer),
             startMongoConsumerAgent(log, producer),
-            startSgtrConsumerAgent(log, producer)
+            startSgtrConsumerAgent(log, producer),
+            startVirtuosoConsumerAgent(log, producer)
         ])
     ).filter(Boolean);
 

--- a/kafnus-ngsi/lib/utils/virtuosoUtils.js
+++ b/kafnus-ngsi/lib/utils/virtuosoUtils.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+ *
+ * This file is part of kafnus
+ *
+ * kafnus is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * kafnus is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with kafnus. If not, see http://www.gnu.org/licenses/.
+ */
+
+const { config } = require('../../kafnusConfig');
+
+const GRAFO_PREFIX = config.graphql.grafo;
+const GRAFO_SUFFIX = config.graphql.grafoSuffix;
+
+const CORE = 'https://ontologia.segittur.es/turismo/def/core#';
+
+function getGrafoName(service) {
+    const grafo = config.graphql.grafoByService
+        ? `${GRAFO_PREFIX}${service}${GRAFO_SUFFIX}`
+        : `${GRAFO_PREFIX}${GRAFO_SUFFIX}`;
+    return grafo;
+}
+
+/**
+ * Generates a subject URI from entity
+ */
+function buildSubjectUri(entityId) {
+    return `urn:segittur:${encodeURIComponent(entityId)}`;
+}
+
+/**
+ * Map an attribute name to a RDF predicate
+ */
+function buildTypeUri(type) {
+    return `${CORE}${type}`;
+}
+
+function buildPredicateUri(attrName) {
+    return `${CORE}${attrName}`;
+}
+
+function toLiteral(value) {
+    if (typeof value === 'boolean') {
+        return `"${value}"^^<http://www.w3.org/2001/XMLSchema#boolean>`;
+    }
+
+    if (typeof value === 'number') {
+        return Number.isInteger(value)
+            ? `"${value}"^^<http://www.w3.org/2001/XMLSchema#integer>`
+            : `"${value}"^^<http://www.w3.org/2001/XMLSchema#decimal>`;
+    }
+
+    return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Converts and NGSI entity in RDF triples
+ */
+function entityToTriples(entityObject) {
+    const triples = [];
+    const entityId = entityObject.externalId || entityObject.id;
+    const subject = buildSubjectUri(entityId);
+
+    if (entityObject.type) {
+        triples.push(
+            `<${subject}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${buildTypeUri(entityObject.type)}> .`
+        );
+    }
+
+    for (const [attrName, attrValue] of Object.entries(entityObject)) {
+        if (attrName === 'id' || attrName === 'externalId' || attrName === 'type' || attrName === 'alterationType') {
+            continue;
+        }
+
+        const predicate = buildPredicateUri(attrName);
+        const values = Array.isArray(attrValue) ? attrValue : [attrValue];
+
+        for (const value of values) {
+            triples.push(`<${subject}> <${predicate}> ${toLiteral(value)} .`);
+        }
+    }
+
+    return triples;
+}
+
+/**
+ * Builds SPARQL for insert/update/change
+ * Simple strategy:
+ * - entitydelete => DELETE WHERE of subject
+ * - entityupdate/entitychange => DELETE WHERE + INSERT DATA
+ * - else => INSERT DATA
+ */
+function buildSparqlForEntity(graphUri, service, entityObject) {
+    const alterationType = String(entityObject.alterationType || '').toLowerCase();
+
+    const entityId = entityObject.externalId || entityObject.id;
+    const subject = buildSubjectUri(entityId);
+    const triples = entityToTriples(entityObject);
+
+    if (alterationType === 'entitydelete') {
+        return `
+DELETE WHERE {
+  GRAPH <${graphUri}> {
+    <${subject}> ?p ?o .
+  }
+}
+        `.trim();
+    }
+
+    if (alterationType === 'entityupdate' || alterationType === 'entitychange') {
+        return `
+DELETE WHERE {
+  GRAPH <${graphUri}> {
+    <${subject}> ?p ?o .
+  }
+};
+
+INSERT DATA {
+  GRAPH <${graphUri}> {
+    ${triples.join('\n    ')}
+  }
+}
+        `.trim();
+    }
+
+    return `
+INSERT DATA {
+  GRAPH <${graphUri}> {
+    ${triples.join('\n    ')}
+  }
+}
+    `.trim();
+}
+
+exports.getGrafoName = getGrafoName;
+exports.buildSparqlForEntity = buildSparqlForEntity;

--- a/kafnus-ngsi/lib/utils/virtuosoUtils.js
+++ b/kafnus-ngsi/lib/utils/virtuosoUtils.js
@@ -19,9 +19,9 @@
 
 const { config } = require('../../kafnusConfig');
 
+// TBD: define new options for virtuoso config about grafo, suffix, and core ontology
 const GRAFO_PREFIX = config.graphql.grafo;
 const GRAFO_SUFFIX = config.graphql.grafoSuffix;
-
 const CORE = 'https://ontologia.segittur.es/turismo/def/core#';
 
 function getGrafoName(service) {
@@ -46,7 +46,8 @@ function buildTypeUri(type) {
 }
 
 function buildPredicateUri(attrName) {
-    return `${CORE}${attrName}`;
+    //return `${CORE}${attrName}`;
+    return `${attrName}`;
 }
 
 function escapeLiteral(value) {

--- a/kafnus-ngsi/lib/utils/virtuosoUtils.js
+++ b/kafnus-ngsi/lib/utils/virtuosoUtils.js
@@ -35,7 +35,7 @@ function getGrafoName(service) {
  * Generates a subject URI from entity
  */
 function buildSubjectUri(entityId) {
-    return `urn:segittur:${encodeURIComponent(entityId)}`;
+    return `urn:segittur:${entityId}`;
 }
 
 /**
@@ -49,22 +49,52 @@ function buildPredicateUri(attrName) {
     return `${CORE}${attrName}`;
 }
 
-function toLiteral(value) {
+function escapeLiteral(value) {
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"').trim();
+}
+
+function toObjectTerm(value) {
+    // simple string
+    if (typeof value === 'string') {
+        return `"${escapeLiteral(value)}"`;
+    }
+
+    // boolean
     if (typeof value === 'boolean') {
         return `"${value}"^^<http://www.w3.org/2001/XMLSchema#boolean>`;
     }
 
+    // number
     if (typeof value === 'number') {
         return Number.isInteger(value)
             ? `"${value}"^^<http://www.w3.org/2001/XMLSchema#integer>`
             : `"${value}"^^<http://www.w3.org/2001/XMLSchema#decimal>`;
     }
 
-    return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    // null/undefined
+    if (value == null) {
+        return null;
+    }
+
+    // Object with uri => IRI
+    if (typeof value === 'object' && value.uri) {
+        return `<${value.uri}>`;
+    }
+
+    // Object with value + lang => lang literal
+    if (typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'value')) {
+        if (value.lang) {
+            return `"${escapeLiteral(value.value)}"@${value.lang}`;
+        }
+        return `"${escapeLiteral(value.value)}"`;
+    }
+
+    // fallback: serialized JSON
+    return `"${escapeLiteral(JSON.stringify(value))}"`;
 }
 
 /**
- * Converts and NGSI entity in RDF triples
+ * Converts and entity object in RDF triples
  */
 function entityToTriples(entityObject) {
     const triples = [];
@@ -86,7 +116,12 @@ function entityToTriples(entityObject) {
         const values = Array.isArray(attrValue) ? attrValue : [attrValue];
 
         for (const value of values) {
-            triples.push(`<${subject}> <${predicate}> ${toLiteral(value)} .`);
+            const objectTerm = toObjectTerm(value);
+            if (!objectTerm) {
+                continue;
+            }
+
+            triples.push(`<${subject}> <${predicate}> ${objectTerm} .`);
         }
     }
 

--- a/kafnus-ngsi/lib/utils/virtuosoUtils.js
+++ b/kafnus-ngsi/lib/utils/virtuosoUtils.js
@@ -25,9 +25,8 @@ const GRAFO_SUFFIX = config.graphql.grafoSuffix;
 const CORE = 'https://ontologia.segittur.es/turismo/def/core#';
 
 function getGrafoName(graphName) {
-    const grafo = graphName != null
-        ? `${GRAFO_PREFIX}${graphName}${GRAFO_SUFFIX}`
-        : `${GRAFO_PREFIX}${GRAFO_SUFFIX}`;
+    const grafo =
+        graphName != null ? `"${GRAFO_PREFIX}${graphName}${GRAFO_SUFFIX}"` : `"${GRAFO_PREFIX}${GRAFO_SUFFIX}"`;
     return grafo;
 }
 

--- a/kafnus-ngsi/lib/utils/virtuosoUtils.js
+++ b/kafnus-ngsi/lib/utils/virtuosoUtils.js
@@ -20,13 +20,13 @@
 const { config } = require('../../kafnusConfig');
 
 // TBD: define new options for virtuoso config about grafo, suffix, and core ontology
-const GRAFO_PREFIX = config.graphql.grafo;
+const GRAFO_PREFIX = config.graphql.grafoPrefix;
 const GRAFO_SUFFIX = config.graphql.grafoSuffix;
 const CORE = 'https://ontologia.segittur.es/turismo/def/core#';
 
-function getGrafoName(service) {
-    const grafo = config.graphql.grafoByService
-        ? `${GRAFO_PREFIX}${service}${GRAFO_SUFFIX}`
+function getGrafoName(graphName) {
+    const grafo = graphName != null
+        ? `${GRAFO_PREFIX}${graphName}${GRAFO_SUFFIX}`
         : `${GRAFO_PREFIX}${GRAFO_SUFFIX}`;
     return grafo;
 }

--- a/tests_end2end/sinks/virtuoso-http-sink.json
+++ b/tests_end2end/sinks/virtuoso-http-sink.json
@@ -1,0 +1,29 @@
+{
+  "name": "virtuoso-http-sink",
+  "config": {
+    "connector.class": "io.aiven.kafka.connect.http.HttpSinkConnector",
+    "tasks.max": "1",
+    "topics": "virtuoso_http",
+
+    "http.url": "http://iot-virtuoso:8890/sparql",
+    "http.authorization.type": "static",
+    "http.headers.content.type": "application/sparql-update",
+
+    "batching.enabled": "false",
+    "batch.max.size": "1",
+
+    "http.timeout": "30",
+
+    "errors.tolerance": "all",
+    "errors.deadletterqueue.topic.name": "raw_errors",
+    "errors.deadletterqueue.context.headers.enable": true,
+    "errors.deadletterqueue.topic.replication.factor": "1",
+    "errors.log.enable": true,
+    "errors.log.include.messages": true,
+    "max.retries": "2",
+    "retry.backoff.ms": "500",
+
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.storage.StringConverter"
+  }
+}


### PR DESCRIPTION
Related with previous works done in cygnus: https://github.com/telefonicaid/fiware-cygnus/pull/2449

And using the flowing sequence to init virtuoso: 
```
     docker exec -it iot-virtuoso isql 1111 dba dba
     GRANT SPARQL_UPDATE TO "SPARQL";
     GRANT EXECUTE ON DB.DBA.SPARQL_INSERT_DICT_CONTENT TO "SPARQL";
     DB.DBA.RDF_DEFAULT_USER_PERMS_SET ('SPARQL', 3);
     DB.DBA.RDF_GRAPH_USER_PERMS_SET ('http://localhost:8890/DAV', 'SPARQL', 3);
```

and retrieving info from virtuoso with: 
``` 
curl -u dba:dba   -G http://localhost:8890/sparql   --data-urlencode 'query=SELECT * FROM <http://localhost:8890/DAV> WHERE { ?s ?p ?o }'
```