### PR TITLE
Fix null asGeoJSON v1.3.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+1.3.1 (May 4th, 2026)
+
+- Fix: handle null values correctly in asGeoJSON, avoiding propagation as null asGeoJSON and using null asWkt instead (#250)
+
 1.3.0 (April 30th, 2026)
 
 - Add: Kafnus NGSI unit tests and CI coverage reporting (#224)

--- a/kafnus-ngsi/lib/utils/ngsiUtils.js
+++ b/kafnus-ngsi/lib/utils/ngsiUtils.js
@@ -133,7 +133,14 @@ function transformSgtrGeoJsonToWkt(entityObject) {
         return;
     }
 
-    const geoJson = parseGeoJsonValue(entityObject[asGeoJsonKey]);
+    const rawGeoJson = entityObject[asGeoJsonKey];
+    if (rawGeoJson === null || (typeof rawGeoJson === 'string' && rawGeoJson.trim().toLowerCase() === 'null')) {
+        entityObject.asWkt = null;
+        delete entityObject[asGeoJsonKey];
+        return;
+    }
+
+    const geoJson = parseGeoJsonValue(rawGeoJson);
     if (!geoJson) {
         return;
     }

--- a/kafnus-ngsi/package.json
+++ b/kafnus-ngsi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kafnus-ngsi",
   "license": "AGPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.3.0-next",
   "description": "kafnus-ngsi based on @confluentinc/kafka-javascript",
   "homepage": "https://github.com/telefonicaid/kafnus",
   "main": "index.js",

--- a/kafnus-ngsi/package.json
+++ b/kafnus-ngsi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kafnus-ngsi",
   "license": "AGPL-3.0-only",
-  "version": "1.3.0-next",
+  "version": "1.3.0",
   "description": "kafnus-ngsi based on @confluentinc/kafka-javascript",
   "homepage": "https://github.com/telefonicaid/kafnus",
   "main": "index.js",

--- a/kafnus-ngsi/tests/ngsiUtils.tdd.test.js
+++ b/kafnus-ngsi/tests/ngsiUtils.tdd.test.js
@@ -281,6 +281,30 @@ describe('ngsiUtils.js', () => {
             expect(entityObject).not.toHaveProperty('asGeoJSON');
         });
 
+        test('replaces null asGeoJSON with asWkt null and removes asGeoJSON', () => {
+            const entityObject = {
+                externalId: 'Location:005',
+                asGeoJSON: null
+            };
+
+            transformSgtrGeoJsonToWkt(entityObject);
+
+            expect(entityObject).toHaveProperty('asWkt', null);
+            expect(entityObject).not.toHaveProperty('asGeoJSON');
+        });
+
+        test('replaces stringified null asGeoJSON with asWkt null and removes asGeoJSON', () => {
+            const entityObject = {
+                externalId: 'Location:006',
+                asGeoJSON: 'null'
+            };
+
+            transformSgtrGeoJsonToWkt(entityObject);
+
+            expect(entityObject).toHaveProperty('asWkt', null);
+            expect(entityObject).not.toHaveProperty('asGeoJSON');
+        });
+
         test('does not alter entity when asGeoJSON is not a valid geometry', () => {
             const entityObject = {
                 externalId: 'Location:001',

--- a/kafnus-ngsi/tests/sgtrConsumerAgent.test.js
+++ b/kafnus-ngsi/tests/sgtrConsumerAgent.test.js
@@ -220,6 +220,46 @@ describe('sgtrConsumerAgent.js', () => {
         expect(commitMessage).toHaveBeenCalledWith(msg);
     });
 
+    test('replaces null asGeoJSON with asWkt null for Location create mutation', async () => {
+        mockTransformSgtrGeoJsonToWkt.mockImplementation((entityObject) => {
+            entityObject.asWkt = null;
+            delete entityObject.asGeoJSON;
+        });
+
+        await startSgtrConsumerAgent(logger, {});
+
+        const msg = {
+            key: Buffer.from('key-5'),
+            value: Buffer.from(
+                JSON.stringify({
+                    data: [
+                        {
+                            alterationType: 'entityCreate',
+                            type: 'Location',
+                            externalId: 'Location:005',
+                            asGeoJSON: null
+                        }
+                    ]
+                })
+            ),
+            headers: []
+        };
+
+        await onData(msg);
+
+        expect(mockTransformSgtrGeoJsonToWkt).toHaveBeenCalledTimes(1);
+        expect(mockBuildMutationCreate).toHaveBeenCalledWith(
+            'es',
+            'Location',
+            expect.objectContaining({
+                externalId: 'Location:005',
+                asWkt: null
+            })
+        );
+        expect(mockBuildMutationCreate.mock.calls[0][2]).not.toHaveProperty('asGeoJSON');
+        expect(commitMessage).toHaveBeenCalledWith(msg);
+    });
+
     test('commits message and logs warning when JSON is invalid', async () => {
         await startSgtrConsumerAgent(logger, {});
 

--- a/tests_end2end/functional/cases/http/002_sgtr_ontology_1.2.0/005_create_location_asgeojson_null_to_aswkt_null/description.txt
+++ b/tests_end2end/functional/cases/http/002_sgtr_ontology_1.2.0/005_create_location_asgeojson_null_to_aswkt_null/description.txt
@@ -1,0 +1,1 @@
+Creates a SGTR Location entity with null asGeoJSON and verifies GraphQL sink sends asWkt: null without propagating asGeoJSON.

--- a/tests_end2end/functional/cases/http/002_sgtr_ontology_1.2.0/005_create_location_asgeojson_null_to_aswkt_null/expected_http.json
+++ b/tests_end2end/functional/cases/http/002_sgtr_ontology_1.2.0/005_create_location_asgeojson_null_to_aswkt_null/expected_http.json
@@ -1,0 +1,19 @@
+[
+    {
+        "url": "http://0.0.0.0:3333",
+        "headers": [
+            {
+                "Content-Type": "application/json"
+            }
+        ],
+        "body": {
+            "query": "createLocation(dti: \"grafo\", input: { object: { externalId: \"Location:005\", country: \"example01\", province: \"example01\", locality: \"example01\", streetAddress: \"example01\", asWkt: null"
+        },
+        "response": {
+            "status": 200,
+            "body": {
+                "status": "OK"
+            }
+        }
+    }
+]

--- a/tests_end2end/functional/cases/http/002_sgtr_ontology_1.2.0/005_create_location_asgeojson_null_to_aswkt_null/input.json
+++ b/tests_end2end/functional/cases/http/002_sgtr_ontology_1.2.0/005_create_location_asgeojson_null_to_aswkt_null/input.json
@@ -1,0 +1,86 @@
+{
+    "name": "location_asgeojson_null_to_aswkt_null_test",
+    "fiware-service": "test",
+    "fiware-servicepath": "/tourism",
+    "subscriptions": {
+        "sgtr": {
+            "description": "kafka sgtr tourism location create with null asGeoJSON",
+            "status": "active",
+            "subject": {
+                "entities": [
+                    {
+                        "idPattern": ".*",
+                        "type": "Location"
+                    }
+                ],
+                "condition": {
+                    "attrs": [
+                        "TimeInstant"
+                    ]
+                },
+                "alterationTypes": [
+                    "entityCreate", "entityUpdate", "entityChange"
+                ]
+            },
+            "notification": {
+                "kafkaCustom": {
+                    "url": "kafka://kafka:29092",
+                    "topic": "smc_raw_sgtr",
+                    "json": {
+                        "data": [
+                            {
+                                "alterationType": "${alterationType}",
+                                "type": "${type}",
+                                "externalId": "${id}",
+                                "asGeoJSON": "${asGeoJSON}",
+                                "country": "${country}",
+                                "province": "${province}",
+                                "locality": "${locality}",
+                                "streetAddress": "${streetAddress}"
+                            }
+                        ]
+                    }
+                },
+                "attrs": [
+                    "TimeInstant"
+                ]
+            }
+        }
+    },
+    "updateEntities": [
+        {
+            "id": "Location:005",
+            "type": "Location",
+            "TimeInstant": {
+                "type": "DateTime",
+                "value": "2025-09-24T13:30:00.000Z",
+                "metadata": {}
+            },
+            "asGeoJSON": {
+                "type": "json",
+                "value": null,
+                "metadata": {}
+            },
+            "country": {
+                "type": "String",
+                "value": "example01",
+                "metadata": {}
+            },
+            "province": {
+                "type": "String",
+                "value": "example01",
+                "metadata": {}
+            },
+            "locality": {
+                "type": "String",
+                "value": "example01",
+                "metadata": {}
+            },
+            "streetAddress": {
+                "type": "String",
+                "value": "example01",
+                "metadata": {}
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Related Issue: #242 

There was a problem, null values in asGeoJSON were being propagated as null asGeoJSON and not as null asWkt.