### PR TITLE
Add option to split historic entities by per-attribute metadata TimeInstant 

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Add: split historic entities by per-attribute metadata TimeInstant so each observation time is written as its own row, gated by the global KAFNUS_NGSI_SPLIT_BY_TIMEINSTANT flag (default off) (#294)

--- a/doc/05_kafnus_ngsi.md
+++ b/doc/05_kafnus_ngsi.md
@@ -596,6 +596,7 @@ The following environment variables configure Kafka connectivity, producer/consu
 | `KAFNUS_NGSI_GROUP_ID` | string | `ngsi-processor` | Base Kafka consumer group ID used by NGSI processor agents. |
 | `KAFNUS_NGSI_PREFIX_TOPIC` | string | `` | Prefix used in all kafka topics (by default no prefix is used). |
 | `KAFNUS_NGSI_SUFFIX_TOPIC` | string | `` | Suffix used in all kafka topics (by default no suffix is used). |
+| `KAFNUS_NGSI_SPLIT_BY_TIMEINSTANT` | boolean | `false` | When enabled, the historic flow splits each entity by per-attribute metadata `TimeInstant`, writing one row per distinct observation time (`TimeInstant` metadata → entity-level `TimeInstant` → `recvtime`). Only the historic flow is affected; lastdata/mutable stay single-row-per-entity. |
 
 ---
 

--- a/docker/docker-compose.ngsi.yml
+++ b/docker/docker-compose.ngsi.yml
@@ -36,6 +36,7 @@ services:
       - KAFNUS_NGSI_LOG_LEVEL=INFO
       - KAFNUS_NGSI_PREFIX_TOPIC=smc_
       - KAFNUS_NGSI_SUFFIX_TOPIC=_processed
+      - KAFNUS_NGSI_SPLIT_BY_TIMEINSTANT=true
     networks:
       - kafka-postgis-net
     ports:

--- a/kafnus-ngsi/kafnusConfig.js
+++ b/kafnus-ngsi/kafnusConfig.js
@@ -209,6 +209,10 @@ const envVarsSchema = {
         KAFNUS_NGSI_SUFFIX_TOPIC: {
             type: 'string',
             default: ''
+        },
+        KAFNUS_NGSI_SPLIT_BY_TIMEINSTANT: {
+            type: 'boolean',
+            default: false
         }
     }
 };
@@ -295,7 +299,8 @@ const config = {
     },
     ngsi: {
         prefix: envVars.KAFNUS_NGSI_PREFIX_TOPIC,
-        suffix: envVars.KAFNUS_NGSI_SUFFIX_TOPIC
+        suffix: envVars.KAFNUS_NGSI_SUFFIX_TOPIC,
+        splitByTimeInstant: envVars.KAFNUS_NGSI_SPLIT_BY_TIMEINSTANT
     }
 };
 

--- a/kafnus-ngsi/lib/consumerAgents/historicConsumerAgent.js
+++ b/kafnus-ngsi/lib/consumerAgents/historicConsumerAgent.js
@@ -59,7 +59,8 @@ async function startHistoricConsumerAgent(log, producer) {
                         suffix,
                         flowSuffix: '_historic',
                         includeTimeinstant: true,
-                        keyFields: ['entityid']
+                        keyFields: ['entityid'],
+                        splitByTimeInstant: config.ngsi.splitByTimeInstant
                     },
                     producer
                 );

--- a/kafnus-ngsi/lib/utils/handleEntityCb.js
+++ b/kafnus-ngsi/lib/utils/handleEntityCb.js
@@ -30,6 +30,8 @@ const { config } = require('../../kafnusConfig');
 const { once } = require('events');
 const Kafka = require('@confluentinc/kafka-javascript');
 
+const TIMEINSTANT_KEY = 'timeinstant';
+
 async function safeProduce(producer, args, { maxWaitMs = 30000 } = {}) {
     const deadline = Date.now() + maxWaitMs;
 
@@ -84,6 +86,78 @@ function buildBaseEntity(entity, context) {
         entitytype: entity.type,
         fiwareservicepath: context.servicepath
     };
+}
+
+// ================= TIMEINSTANT SPLIT =================
+
+// Case-insensitive lookup of a `TimeInstant.value` inside an object. Reused for
+// both the entity-level attribute and per-attribute metadata, since IoT-Agent
+// casing may vary ('TimeInstant', 'timeinstant', ...).
+function findTimeInstantValue(source) {
+    if (!source || typeof source !== 'object') {
+        return undefined;
+    }
+
+    for (const [key, val] of Object.entries(source)) {
+        if (key.toLowerCase() === TIMEINSTANT_KEY) {
+            return val?.value;
+        }
+    }
+
+    return undefined;
+}
+
+/*
+ * Splits a single NGSI entity into one sub-entity per distinct resolved
+ * TimeInstant, so the historic flow can write one row per observation time.
+ * Data attributes are grouped by their resolved timestamp and each group
+ * becomes a standalone NGSI-shaped entity (same id/type) whose TimeInstant is
+ * overridden with that group's resolved value, so the historic row carries the
+ * actual observation time of the data it contains. Each sub-entity then flows
+ * through the regular processing path (and existing timeinstant-based key)
+ * unchanged.
+ *
+ * The original entity is returned only when it has no data attributes (so
+ * there is nothing to group, but the row must still be emitted just like the
+ * non-split path does). In every other case the entity is rebuilt so each row
+ * carries its resolved observation time — including when a single shared
+ * metadata timestamp differs from the entity-level TimeInstant.
+ */
+function splitEntityByTimeInstant(entity) {
+    const entityTimeInstant = findTimeInstantValue(entity);
+    const groups = new Map();
+
+    for (const [rawName, attrData] of Object.entries(entity)) {
+        const attrName = rawName.toLowerCase();
+
+        if (isIgnoredAttr(attrName) || attrName === TIMEINSTANT_KEY) {
+            continue;
+        }
+
+        const ts = findTimeInstantValue(attrData?.metadata) ?? entityTimeInstant;
+        const groupKey = ts ?? '';
+
+        if (!groups.has(groupKey)) {
+            groups.set(groupKey, { ts, attrs: {} });
+        }
+        groups.get(groupKey).attrs[rawName] = attrData;
+    }
+
+    const groupList = Array.from(groups.values());
+
+    // An attribute-less entity has nothing to group, but must still emit its
+    // row like the non-split path — mapping an empty list would drop it.
+    if (groupList.length === 0) {
+        return [entity];
+    }
+
+    return groupList.map(({ ts, attrs }) => {
+        const subEntity = { id: entity.id, type: entity.type, ...attrs };
+        if (ts != null) {
+            subEntity.TimeInstant = { type: 'DateTime', value: ts };
+        }
+        return subEntity;
+    });
 }
 
 // ================= GEO =================
@@ -242,7 +316,14 @@ async function processEntity({
 async function handleEntityCb(
     logger,
     rawValue,
-    { headers = [], suffix = '', flowSuffix = '_historic', includeTimeinstant = true, keyFields = ['entityid'] } = {},
+    {
+        headers = [],
+        suffix = '',
+        flowSuffix = '_historic',
+        includeTimeinstant = true,
+        keyFields = ['entityid'],
+        splitByTimeInstant = false
+    } = {},
     producer
 ) {
     try {
@@ -258,16 +339,20 @@ async function handleEntityCb(
         const topicName = buildTopicName(context.service, suffix);
 
         for (const entity of entities) {
-            await processEntity({
-                entity,
-                context,
-                topicName,
-                flowSuffix,
-                includeTimeinstant,
-                keyFields,
-                producer,
-                logger
-            });
+            const subEntities = splitByTimeInstant ? splitEntityByTimeInstant(entity) : [entity];
+
+            for (const subEntity of subEntities) {
+                await processEntity({
+                    entity: subEntity,
+                    context,
+                    topicName,
+                    flowSuffix,
+                    includeTimeinstant,
+                    keyFields,
+                    producer,
+                    logger
+                });
+            }
         }
     } catch (err) {
         handleError(err, logger);
@@ -276,3 +361,4 @@ async function handleEntityCb(
 
 module.exports.handleEntityCb = handleEntityCb;
 module.exports.safeProduce = safeProduce;
+module.exports.splitEntityByTimeInstant = splitEntityByTimeInstant;

--- a/kafnus-ngsi/tests/handleEntityCb.test.js
+++ b/kafnus-ngsi/tests/handleEntityCb.test.js
@@ -51,7 +51,7 @@ jest.mock('../lib/utils/ngsiUtils', () => ({
 }));
 
 const ngsiUtils = require('../lib/utils/ngsiUtils');
-const { safeProduce, handleEntityCb } = require('../lib/utils/handleEntityCb');
+const { safeProduce, handleEntityCb, splitEntityByTimeInstant } = require('../lib/utils/handleEntityCb');
 
 describe('handleEntityCb.js', () => {
     let logger;
@@ -126,6 +126,116 @@ describe('handleEntityCb.js', () => {
             });
 
             await expect(safeProduce(producer, ['topic-a'], { maxWaitMs: 25 })).rejects.toThrow('queue full');
+        });
+    });
+
+    describe('splitEntityByTimeInstant', () => {
+        test('groups attributes by resolved TimeInstant, preferring per-attribute metadata', () => {
+            const entity = {
+                id: 'Sensor1',
+                type: 'Sensor',
+                TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' },
+                temperature: {
+                    value: 23.5,
+                    type: 'Float',
+                    metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' } }
+                },
+                humidity: {
+                    value: 65.0,
+                    type: 'Float',
+                    metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' } }
+                }
+            };
+
+            const result = splitEntityByTimeInstant(entity);
+
+            expect(result).toEqual([
+                {
+                    id: 'Sensor1',
+                    type: 'Sensor',
+                    temperature: entity.temperature,
+                    TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' }
+                },
+                {
+                    id: 'Sensor1',
+                    type: 'Sensor',
+                    humidity: entity.humidity,
+                    TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' }
+                }
+            ]);
+        });
+
+        test('falls back to the entity-level TimeInstant for attributes without metadata', () => {
+            const entity = {
+                id: 'Sensor1',
+                type: 'Sensor',
+                TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' },
+                temperature: {
+                    value: 23.5,
+                    type: 'Float',
+                    metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' } }
+                },
+                humidity: { value: 65.0, type: 'Float' }
+            };
+
+            const result = splitEntityByTimeInstant(entity);
+
+            expect(result).toHaveLength(2);
+            const humidityGroup = result.find((e) => e.humidity);
+            expect(humidityGroup.TimeInstant.value).toBe('2024-06-01T10:00:05Z');
+        });
+
+        test('overrides TimeInstant when all attributes share one metadata timestamp differing from the entity-level one', () => {
+            const entity = {
+                id: 'Sensor1',
+                type: 'Sensor',
+                TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' },
+                temperature: {
+                    value: 23.5,
+                    type: 'Float',
+                    metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' } }
+                },
+                humidity: {
+                    value: 65.0,
+                    type: 'Float',
+                    metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' } }
+                }
+            };
+
+            const result = splitEntityByTimeInstant(entity);
+
+            // Single row (both attributes agree) but at the observation time, not the entity time.
+            expect(result).toEqual([
+                {
+                    id: 'Sensor1',
+                    type: 'Sensor',
+                    temperature: entity.temperature,
+                    humidity: entity.humidity,
+                    TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' }
+                }
+            ]);
+        });
+
+        test('returns the original entity when every attribute shares one timestamp', () => {
+            const entity = {
+                id: 'Sensor1',
+                type: 'Sensor',
+                TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' },
+                temperature: { value: 23.5, type: 'Float' },
+                humidity: { value: 65.0, type: 'Float' }
+            };
+
+            expect(splitEntityByTimeInstant(entity)).toEqual([entity]);
+        });
+
+        test('returns the original entity when there is no TimeInstant at all', () => {
+            const entity = {
+                id: 'Sensor1',
+                type: 'Sensor',
+                temperature: { value: 23.5, type: 'Float' }
+            };
+
+            expect(splitEntityByTimeInstant(entity)).toEqual([entity]);
         });
     });
 
@@ -220,6 +330,64 @@ describe('handleEntityCb.js', () => {
                 'producer failure'
             );
             expect(logger.error).toHaveBeenCalled();
+        });
+
+        test('splits an entity into one message per distinct per-attribute TimeInstant when enabled', async () => {
+            const producer = { produce: jest.fn() };
+
+            const rawValue = JSON.stringify({
+                data: [
+                    {
+                        id: 'Sensor1',
+                        type: 'Sensor',
+                        TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' },
+                        temperature: {
+                            value: 23.5,
+                            type: 'Float',
+                            metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' } }
+                        },
+                        humidity: {
+                            value: 65.0,
+                            type: 'Float',
+                            metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' } }
+                        }
+                    }
+                ]
+            });
+
+            await handleEntityCb(
+                logger,
+                rawValue,
+                { headers: [], suffix: '_historic', flowSuffix: '_historic', splitByTimeInstant: true },
+                producer
+            );
+
+            // Two distinct observation times -> two Kafka messages.
+            expect(producer.produce).toHaveBeenCalledTimes(2);
+        });
+
+        test('does not split when splitByTimeInstant is not set (backward compatible)', async () => {
+            const producer = { produce: jest.fn() };
+
+            const rawValue = JSON.stringify({
+                data: [
+                    {
+                        id: 'Sensor1',
+                        type: 'Sensor',
+                        TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:05Z' },
+                        temperature: {
+                            value: 23.5,
+                            type: 'Float',
+                            metadata: { TimeInstant: { type: 'DateTime', value: '2024-06-01T10:00:00Z' } }
+                        },
+                        humidity: { value: 65.0, type: 'Float' }
+                    }
+                ]
+            });
+
+            await handleEntityCb(logger, rawValue, { headers: [] }, producer);
+
+            expect(producer.produce).toHaveBeenCalledTimes(1);
         });
 
         test('rethrows ERR__QUEUE_FULL from safeProduce without calling logger.error', async () => {

--- a/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/description.txt
+++ b/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/description.txt
@@ -1,0 +1,5 @@
+Per-attribute TimeInstant handling. A single Sensor update carries different
+per-attribute TimeInstant metadata (temperature observed at 10:00:00, humidity
+at 10:00:05). The historic flow must split the entity into one row per distinct
+observation time (temperature@10:00:00, humidity@10:00:05), while the lastdata
+flow must keep a single row with the full entity at the latest TimeInstant.

--- a/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/expected_pg.json
+++ b/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/expected_pg.json
@@ -1,0 +1,15 @@
+[
+{
+  "table": "test.split_sensor",
+  "rows": [
+    {"entityid": "Sensor1", "entitytype": "Sensor", "timeinstant": "2024-06-01T10:00:00Z", "temperature": 23.5, "fiwareservicepath": "/split"},
+    {"entityid": "Sensor1", "entitytype": "Sensor", "timeinstant": "2024-06-01T10:00:05Z", "humidity": 65.0, "fiwareservicepath": "/split"}
+  ]
+},
+{
+  "table": "test.split_sensor_lastdata",
+  "rows": [
+    {"entityid": "Sensor1", "entitytype": "Sensor", "timeinstant": "2024-06-01T10:00:05Z", "temperature": 23.5, "humidity": 65.0, "fiwareservicepath": "/split"}
+  ]
+}
+]

--- a/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/input.json
+++ b/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/input.json
@@ -1,0 +1,58 @@
+{
+  "name": "per_attr_timeinstant_split",
+  "fiware-service": "test",
+  "fiware-servicepath": "/split",
+  "subscriptions": {
+    "historic": {
+      "description": "Sensor:HISTORIC:split:historic",
+      "status": "active",
+      "subject": {
+        "entities": [{ "idPattern": ".*", "type": "Sensor" }],
+        "condition": { "attrs": ["TimeInstant"] }
+      },
+      "notification": {
+        "kafkaCustom": {
+          "url": "kafka://kafka:29092",
+          "topic": "smc_raw_historic"
+        },
+        "attrs": ["TimeInstant", "temperature", "humidity"]
+      }
+    },
+    "lastdata": {
+      "description": "Sensor:LASTDATA:split:lastdata",
+      "status": "active",
+      "subject": {
+        "entities": [{ "idPattern": ".*", "type": "Sensor" }],
+        "condition": { "attrs": ["TimeInstant"] }
+      },
+      "notification": {
+        "kafkaCustom": {
+          "url": "kafka://kafka:29092",
+          "topic": "smc_raw_lastdata"
+        },
+        "attrs": ["TimeInstant", "temperature", "humidity"]
+      }
+    }
+  },
+  "updateEntities": [
+    {
+      "id": "Sensor1",
+      "type": "Sensor",
+      "TimeInstant": { "type": "DateTime", "value": "2024-06-01T10:00:05Z" },
+      "temperature": {
+        "value": 23.5,
+        "type": "Float",
+        "metadata": {
+          "TimeInstant": { "type": "DateTime", "value": "2024-06-01T10:00:00Z" }
+        }
+      },
+      "humidity": {
+        "value": 65.0,
+        "type": "Float",
+        "metadata": {
+          "TimeInstant": { "type": "DateTime", "value": "2024-06-01T10:00:05Z" }
+        }
+      }
+    }
+  ]
+}

--- a/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/setup.sql
+++ b/tests_end2end/functional/cases/postgis/011_per_attr_timeinstant/001_split/setup.sql
@@ -1,0 +1,25 @@
+-- Historic: one row per distinct per-attribute TimeInstant
+DROP TABLE IF EXISTS test.split_sensor;
+CREATE TABLE IF NOT EXISTS test.split_sensor (
+    recvtime TIMESTAMPTZ NOT NULL DEFAULT now(),
+    fiwareservicepath TEXT,
+    entityid TEXT,
+    entitytype TEXT,
+    timeinstant TIMESTAMPTZ,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    CONSTRAINT split_sensor_pkey PRIMARY KEY (timeinstant, entityid)
+);
+
+-- Lastdata: single latest row (must NOT be split)
+DROP TABLE IF EXISTS test.split_sensor_lastdata;
+CREATE TABLE IF NOT EXISTS test.split_sensor_lastdata (
+    recvtime TIMESTAMPTZ NOT NULL DEFAULT now(),
+    fiwareservicepath TEXT,
+    entityid TEXT,
+    entitytype TEXT,
+    timeinstant TIMESTAMPTZ,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    CONSTRAINT split_sensor_lastdata_pkey PRIMARY KEY (entityid)
+);


### PR DESCRIPTION
Relate Issue: #294

Adds a config option (default false -> old behavior) to split entities of the historic flow by its TimeInstant metadata if multiple different timeinstants are set. Overrides TimeInstant of the entity when enabled which keeps the flow to Kafnus-connect unchanged.